### PR TITLE
Update en_GB.po

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -101,7 +101,7 @@ msgstr ""
 #. in 24-hour mode.
 #: ../libgnome-desktop/gnome-wall-clock.c:299
 msgid "%a %b %e, %R:%S"
-msgstr "%a %b %e, %R:%S"
+msgstr "%a %e %b, %R:%S"
 
 #: ../libgnome-desktop/gnome-wall-clock.c:300
 msgid "%a %b %e, %R"
@@ -131,11 +131,11 @@ msgstr "%R"
 #. for AM/PM.
 #: ../libgnome-desktop/gnome-wall-clock.c:315
 msgid "%a %b %e, %l:%M:%S %p"
-msgstr "%a %b %e, %l:%M:%S %p"
+msgstr "%a %e %b, %l:%M:%S %p"
 
 #: ../libgnome-desktop/gnome-wall-clock.c:316
 msgid "%a %b %e, %l:%M %p"
-msgstr "%a %b %e, %l:%M %p"
+msgstr "%a %e %b, %l:%M %p"
 
 #. Translators: This is a time format with day used
 #. for AM/PM.


### PR DESCRIPTION
The **Date format in Great Britain** is most commonly **day month year** (rather than the American month day year).
Accordingly, I updated **msgstr** instances where format was '... %b %e ...' to '... %e %b ...'

ISO 8601 is also now becoming more popular globally, but I don't see a key for this yet.